### PR TITLE
make sure users running hook is gitlab user

### DIFF
--- a/hooks/pre-receive
+++ b/hooks/pre-receive
@@ -10,7 +10,8 @@ repo_path = Dir.pwd
 require_relative '../lib/gitlab_custom_hook'
 require_relative '../lib/gitlab_access'
 
-if GitlabAccess.new(repo_path, key_id, refs).exec &&
+if (Process.uid != Process::UID.from_name(GitlabConfig.new.config['user']) ||
+    GitlabAccess.new(repo_path, key_id, refs).exec) &&
     GitlabCustomHook.new.pre_receive(refs, repo_path)
   exit 0
 else


### PR DESCRIPTION
In order to not break systems / use cases where more than the gitlab user should have valid access to operate on the repos, enable alternate users to skip the access check. In these cases, system acl and file system permissions govern access rather than gitlab.
